### PR TITLE
feat: derive expected traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 use binrw::{BinRead, BinResult, BinWrite, Endian};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnsignedVarint(pub u64);
 
 impl BinRead for UnsignedVarint {


### PR DESCRIPTION
# Summary

Derive standard Rust traits that users of this library would expect from the `UnsignedVarint` type. 