### PR TITLE
chore: add PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,27 @@
+name: PR checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cargo fmt
+        run: |
+          cargo fmt
+          git config --global user.name 'cargofmt robot'
+          git diff --quiet && git diff --staged --quiet || git commit -am "chore: rustfmt"
+          git push
+      - name: Cargo test
+        run: |
+          cargo test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ impl BinRead for UnsignedVarint {
         _: Endian,
         _: Self::Args<'_>,
     ) -> BinResult<Self> {
-                        let mut number = 0;
+        let mut number = 0;
         // used to track the number of bits that need to be shifted left to place the number from
         // each byte correctly. The last byte we read will be the most significant one becasuse of
         // how the serialization process works. The least significant bytes are encoded first.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ impl BinRead for UnsignedVarint {
         _: Endian,
         _: Self::Args<'_>,
     ) -> BinResult<Self> {
-        let mut number = 0;
+                        let mut number = 0;
         // used to track the number of bits that need to be shifted left to place the number from
         // each byte correctly. The last byte we read will be the most significant one becasuse of
         // how the serialization process works. The least significant bytes are encoded first.


### PR DESCRIPTION
## Summary

Add PR checks to ensure that code is formatted with `rustfmt` and code compiles and all tests pass. 